### PR TITLE
ignoring utf decoding errors

### DIFF
--- a/tail.py
+++ b/tail.py
@@ -247,7 +247,7 @@ class KafkaProd(object):
                             break
 
 def convert(line):
-    udata=line.decode("utf-8")
+    udata=line.decode("utf-8", errors="ignore")
     return udata.encode("ascii","ignore")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes data may have some wild encoding, ignoring those log lines at these step itself as they would be a problem for kafka.
